### PR TITLE
Fixed package name in launch to use new name

### DIFF
--- a/launch/system_monitor.launch
+++ b/launch/system_monitor.launch
@@ -1,21 +1,22 @@
+<?xml version="1.0"?>
 <launch>
   <arg name="machine_name" default="$(optenv HOSTNAME localhost)"/>
-  <arg name="config_file" default="$(find system_monitor)/config/system_monitor.yaml"/>
+  <arg name="config_file" default="$(find ros_system_monitor)/config/system_monitor.yaml"/>
   <arg name="output" default="log"/>
 
   <group ns="system_monitor/$(arg machine_name)">
-    <node name="cpu_monitor" pkg="system_monitor" type="cpu_monitor.py"
+    <node name="cpu_monitor" pkg="ros_system_monitor" type="cpu_monitor.py"
       output="$(arg output)" respawn="true"/>
-    <node name="hdd_monitor" pkg="system_monitor" type="hdd_monitor.py"
+    <node name="hdd_monitor" pkg="ros_system_monitor" type="hdd_monitor.py"
       output="$(arg output)" respawn="true"/>
-    <node name="mem_monitor" pkg="system_monitor" type="mem_monitor.py"
+    <node name="mem_monitor" pkg="ros_system_monitor" type="mem_monitor.py"
       output="$(arg output)" respawn="true"/>
-    <node name="ntp_monitor" pkg="system_monitor" type="ntp_monitor.py"
+    <node name="ntp_monitor" pkg="ros_system_monitor" type="ntp_monitor.py"
       output="$(arg output)" respawn="true"/>
-    <node name="net_monitor" pkg="system_monitor" type="net_monitor.py"
-      output="$(arg output)" respawn="true"/>      
+    <node name="net_monitor" pkg="ros_system_monitor" type="net_monitor.py"
+      output="$(arg output)" respawn="true"/>
   </group>
-  
+
   <rosparam command="load" file="$(arg config_file)"
     ns="system_monitor/$(arg machine_name)"/>
 </launch>

--- a/package.xml
+++ b/package.xml
@@ -10,11 +10,11 @@
   <license>GNU Lesser General Public License (LGPL)</license>
   <url>http://github.com/ethz-asl/ros-system-monitor</url>
   <buildtool_depend>catkin</buildtool_depend>
-  
+
   <build_depend>rospy</build_depend>
   <build_depend>std_msgs</build_depend>
   <build_depend>diagnostic_msgs</build_depend>
-  
+
   <run_depend>rospy</run_depend>
   <run_depend>std_msgs</run_depend>
   <run_depend>diagnostic_msgs</run_depend>


### PR DESCRIPTION
Also added a xml version header (which vim and perhaps other text editors use for syntax highlighting), and deleted some instances of spaces before a new line.